### PR TITLE
Add typescript (ts/tsx) to supported extensions

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 
-var supportedExtensions = ['.js', '.jsx'];
+var supportedExtensions = ['.js', '.jsx', '.ts', '.tsx'];
 
 module.exports.walk = function walk(dirPath, files = []) {
   var list = fs.readdirSync(dirPath);


### PR DESCRIPTION
This PR adds extensions '.ts', '.tsx' so d2-i18n-extract can be used in typescript projects.